### PR TITLE
Disable GitHub Packages

### DIFF
--- a/azure-pipelines/release-pipeline.yml
+++ b/azure-pipelines/release-pipeline.yml
@@ -21,12 +21,12 @@ stages:
             Dockerfile: '$(System.DefaultWorkingDirectory)/Dockerfile'
             tags: latest
 
-        - task: Docker@2
-          displayName: 'Publish to GitHub Packages'
-          inputs:
-            containerRegistry: 'GitHub Packages'
-            repository: 'CyberDiscovery/elections-bot/elections-bot'
-            tags: latest
+#        - task: Docker@2
+#          displayName: 'Publish to GitHub Packages'
+#          inputs:
+#            containerRegistry: 'GitHub Packages'
+#            repository: 'CyberDiscovery/elections-bot/elections-bot'
+#            tags: latest
   
   - stage: Deploy
     jobs:


### PR DESCRIPTION
GitHub packages is currently breaking the deployment pipeline. I have a ticket open with GitHub, but until it's resolved this needs to be closed.